### PR TITLE
fix: sometime pcap_next returns 0 which lead to segment fault

### DIFF
--- a/dpi.c
+++ b/dpi.c
@@ -213,6 +213,7 @@ void *xcap(void *v_dev_name) {
 
   while (runtime__xcap) {
     packet = pcap_next(handle, &header);
+    if(!packet) continue;
     ep = (struct ether_header *)packet;
     ether_type = ntohs(ep->ether_type);
     if (ether_type != ETHERTYPE_IP) {


### PR DESCRIPTION
Meet a segmentation fault situation:
Thread 2 "boopkit" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff7cc2700 (LWP 936627)]
0x00000000003100d9 in xcap (v_dev_name=0x315f68 <cfg+12292>) at dpi.c:217
217         ether_type = ntohs(ep->ether_type);
(gdb) bt
#0  0x00000000003100d9 in xcap (v_dev_name=0x315f68 <cfg+12292>) at dpi.c:217
#1  0x00007ffff7ede609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#2  0x00007ffff7e03133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb) p ep
$1 = (struct ether_header *) 0x0
(gdb) p packet
$2 = (const u_char *) 0x0


According to man pcap_next():
pcap_next() returns a pointer  to  the  packet  data  on  success,  and
   returns  NULL  if  an  error occured, or if no packets were read from a
   live capture (if, for example, they were discarded because they  didn't
   pass the packet filter, or if, on platforms that support a read timeout
   that starts before any packets arrive, the timeout expires  before  any
   packets  arrive, or if the file descriptor for the capture device is in
   non-blocking mode and no packets were available to be read), or  if  no
   more  packets are available in a ``savefile.''  Unfortunately, there is
   no way to determine whether an error occured or not.

pcap_next() may returns NULL. So bybass it to avoid segmentation fault.

